### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If you prefer to build from source or want the latest development version:
 3. Navigate to the project directory:
 
    ```bash
-   cd grabit.sh
+   cd grabitsh
    ```
 
 4. Build the project:


### PR DESCRIPTION
Directory it clones to is the name of the repo which does not include the . Also noticed the build command complained about VCS stamping, assuming that's a 'temporary issue and will be solved later'.

$ go build -o grabitsh
error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping.
/app$ go build -o grabitsh -buildvcs=false